### PR TITLE
Revert "Remove context"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
         id: build
         with:
           builder: ${{steps.buildx.outputs.name}}
+          context: .
           platforms: ${{env.PLATFORMS}}
           cache-from: ${{env.CACHE_FROM}}
           cache-to: ${{env.CACHE_TO}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
         id: build
         with:
           builder: ${{steps.buildx.outputs.name}}
+          context: .
           platforms: ${{env.PLATFORMS}}
           tags: ${{env.PACKAGE_TEMP}}
           cache-from: ${{env.CACHE_FROM}}
@@ -87,6 +88,7 @@ jobs:
         uses: docker/build-push-action@v2.4.0
         with:
           builder: ${{steps.buildx.outputs.name}}
+          context: .
           platforms: ${{env.PLATFORMS}}
           tags: ${{env.TAGS}}
           cache-from: ${{env.CACHE_FROM}}


### PR DESCRIPTION
Reverts devpow112/docker-base-ubuntu#108. This causes the digest to be different each run which prevents the check for changes.