### PR TITLE
Add `s390x` and `riscv64`, drop `ppc64le`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,15 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      PLATFORMS: linux/amd64,linux/arm/v7,linux/arm64,linux/riscv64,linux/s390x
     steps:
       - name: Checkout
         uses: actions/checkout@v2.4.0
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1.2.0
         with:
-          platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le
+          platforms: ${{env.PLATFORMS}}
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1.6.0
@@ -51,7 +53,7 @@ jobs:
         with:
           builder: ${{steps.buildx.outputs.name}}
           context: .
-          platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le
+          platforms: ${{env.PLATFORMS}}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache
           push: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
         ports:
           - 5000:5000
     env:
+      PLATFORMS: linux/amd64,linux/arm/v7,linux/arm64,linux/riscv64,linux/s390x
       PACKAGE: ghcr.io/${{github.repository_owner}}/base-ubuntu
       PACKAGE_TEMP: localhost:5000/${{github.repository_owner}}/base-ubuntu
     steps:
@@ -34,7 +35,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1.2.0
         with:
-          platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le
+          platforms: ${{env.PLATFORMS}}
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1.6.0
@@ -53,7 +54,7 @@ jobs:
         with:
           builder: ${{steps.buildx.outputs.name}}
           context: .
-          platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le
+          platforms: ${{env.PLATFORMS}}
           tags: ${{env.PACKAGE_TEMP}}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache
@@ -147,7 +148,7 @@ jobs:
         with:
           builder: ${{steps.buildx.outputs.name}}
           context: .
-          platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le
+          platforms: ${{env.PLATFORMS}}
           tags: ${{steps.info.outputs.docker-tags}}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,6 @@ RUN export DEBIAN_FRONTEND='noninteractive' && \
     PLATFORM_TRANSFORM="${PLATFORM_TRANSFORM};s/^amd64/x86_64/" && \
     PLATFORM_TRANSFORM="${PLATFORM_TRANSFORM};s/^arm64/aarch64/" && \
     PLATFORM_TRANSFORM="${PLATFORM_TRANSFORM};s/^arm\/v7/armhf/" && \
-    PLATFORM_TRANSFORM="${PLATFORM_TRANSFORM};s/^ppc64le/riscv64/" && \
     ARCH=$(echo ${TARGETPLATFORM} | sed "${PLATFORM_TRANSFORM}") && \
     echo "###### Platform mapping s6 overlay: ${TARGETPLATFORM} => ${ARCH}" && \
     URL='https://github.com/just-containers/s6-overlay/releases/download' && \


### PR DESCRIPTION
The s6 overlay group dropped `ppc64le` support with version 3 and added more modern platforms.