### PR TITLE
Revert "Bump s6 overlay from 3.1.0.1 to 3.1.1.0"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:focal-20220531
 ARG TARGETPLATFORM
 ARG LANGUAGE=en_US
 ARG ENCODING=UTF-8
-ARG S6_OVERLAY_VERSION=3.1.1.0
+ARG S6_OVERLAY_VERSION=3.1.0.1
 
 # set default shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
Reverts devpow112/docker-base-ubuntu#330