### PR TITLE
Remove `riscv64` as supported platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      PLATFORMS: linux/amd64,linux/arm/v7,linux/arm64,linux/riscv64,linux/s390x
+      PLATFORMS: linux/amd64,linux/arm/v7,linux/arm64,linux/s390x
     services:
       registry:
         image: registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     needs:
       - ci
     env:
-      PLATFORMS: linux/amd64,linux/arm/v7,linux/arm64,linux/riscv64,linux/s390x
+      PLATFORMS: linux/amd64,linux/arm/v7,linux/arm64,linux/s390x
       PACKAGE: ghcr.io/${{github.repository_owner}}/base-ubuntu
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ docker build \
 ### Arguments
 
 - `TARGETPLATFORM` - Set by [Docker Buildx] automatically. Currently supported
-  platforms are `amd64`, `arm/v7`, `arm64`, `riscv64` and `s390x`. This should
-  be set automatically even if building locally using standard [Docker CLI].
+  platforms are `amd64`, `arm/v7`, `arm64` and `s390x`. This should be set
+  automatically even if building locally using standard [Docker CLI].
 - `LANGUAGE` - The language code that is set globally for the system. Defaults
   to `en_US`. See [locale] for more details.
 - `ENCODING` - Character encoding that is set globally for the system. Defaults


### PR DESCRIPTION
The official ubuntu image has dropped support for `riscv64`.